### PR TITLE
Fixed: Body rotation in Godot 3+

### DIFF
--- a/box.gd
+++ b/box.gd
@@ -23,12 +23,17 @@ func _ready():
 func _integrate_forces(s):
 	if (not host and state != null and state_timer < STATE_EXPIRATION_TIME):
 		state_timer += s.get_step()
-		var transform = s.get_transform()
-		var pos = lerp_pos(transform.get_origin(), state[0], 1.0 - ALPHA)
+
+		# Lerp
 		var rot = slerp_rot(transform.get_rotation(), state[1], ALPHA)
-		var x_axis = Vector2(cos(rot), -sin(rot))
-		var y_axis = Vector2(sin(rot), cos(rot))
-		s.set_transform(Transform2D(x_axis, y_axis, pos))
+		var pos = lerp_pos(transform.get_origin(), state[0], 1.0 - ALPHA)
+
+		# Transforms
+		var transform = s.get_transform().rotated(rot - get_rotation())
+		transform.origin = pos
+		s.set_transform(transform)
+
+		# Forces
 		s.set_linear_velocity(state[2])
 		s.set_angular_velocity(state[3])
 


### PR DESCRIPTION
In the current demo for Godot 3+, rotation seems to be acting weird. It often rotates in the wrong direction or jitters around. Sometimes it just does not correct itself at all.

![image](https://user-images.githubusercontent.com/6717505/151636445-6ff1eb3d-0b27-473f-894e-5420367e11a1.png)

 I've converted the integrate forces to use alternative methods of moving a physics body, which seems to fix things.